### PR TITLE
[보관함] 인증 수정 및 Git 히스토리 문제 해결

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -95,6 +95,26 @@ services:
       redis:
         condition: service_started
 
+  # Store Service
+  store-service:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.store
+    container_name: dd-store-service
+    ports: [ "8084:8084" ]
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://shared-db:5432/dorandoran
+      - SPRING_DATASOURCE_USERNAME=doran
+      - SPRING_DATASOURCE_PASSWORD=doran
+      - SPRING_JPA_HIBERNATE_DEFAULT_SCHEMA=store_schema
+      - FEIGN_CHAT_SERVICE_URL=http://chat-service:8083
+    depends_on:
+      shared-db:
+        condition: service_healthy
+      chat-service:
+        condition: service_started
+
   # Batch Service
   batch-service:
     build:

--- a/gateway/src/main/java/com/dorandoran/gateway/controller/HomeController.java
+++ b/gateway/src/main/java/com/dorandoran/gateway/controller/HomeController.java
@@ -27,7 +27,8 @@ public class HomeController {
             "auth", "/api/auth/**",
             "user", "/api/users/**",
             "chat", "/api/chat/**",
-            "batch", "/api/batch/**"
+            "batch", "/api/batch/**",
+            "store", "/api/store/**"
         ));
         return Mono.just(response);
     }

--- a/store/src/main/java/com/dorandoran/store/client/ChatServiceClient.java
+++ b/store/src/main/java/com/dorandoran/store/client/ChatServiceClient.java
@@ -1,0 +1,33 @@
+package com.dorandoran.store.client;
+
+import com.dorandoran.store.client.dto.ChatRoomDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Chat Service Feign Client
+ * 채팅과 보관함 연결
+ */
+@FeignClient(
+    name = "chat-service",
+    url = "${feign.chat-service.url:http://localhost:8083}",
+    fallback = ChatServiceClientFallback.class
+)
+public interface ChatServiceClient {
+
+  /**
+   * 채팅방 정보 조회
+   * @param chatroomId 채팅방 ID
+   * @param userId 사용자 ID (권한 체크용)
+   * @return 채팅방 정보
+   */
+  @GetMapping("/api/chat/chatrooms/{chatroomId}")
+  ChatRoomDto getChatRoom(
+      @PathVariable("chatroomId") UUID chatroomId,
+      @RequestParam("userId") UUID userId
+  );
+}

--- a/store/src/main/java/com/dorandoran/store/client/ChatServiceClientFallback.java
+++ b/store/src/main/java/com/dorandoran/store/client/ChatServiceClientFallback.java
@@ -1,0 +1,28 @@
+package com.dorandoran.store.client;
+
+import com.dorandoran.store.client.dto.ChatRoomDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Chat Service Feign Client Fallback
+ * Circuit Breaker 패턴
+ */
+@Component
+@Slf4j
+public class ChatServiceClientFallback implements ChatServiceClient {
+
+  @Override
+  public ChatRoomDto getChatRoom(UUID chatroomId, UUID userId) {
+    log.warn("Chat Service 호출 실패 - Fallback 실행: chatroomId={}, userId={}",
+        chatroomId, userId);
+
+    // Fallback 응답: name = "Unknown"
+    return ChatRoomDto.builder()
+        .id(chatroomId)
+        .name("Unknown")
+        .build();
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/config/SecurityConfig.java
+++ b/store/src/main/java/com/dorandoran/store/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.dorandoran.store.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Security 설정
+ * Store Service는 내부 MSA 서비스로, API Gateway에서 이미 인증을 처리함 - 기존 CORS 처리 코드 삭제
+ * 전달된 X-User-Id 헤더만 검증하고 Security Context는 사용하지 않음
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .authorizeHttpRequests(authz -> authz
+            // Swagger UI 접근 허용
+            .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
+                "/api-docs/**").permitAll()
+            // Actuator 엔드포인트 허용
+            .requestMatchers("/actuator/**").permitAll()
+            // API 엔드포인트는 MSA 내부 통신이므로 허용 (API Gateway가 인증 처리)
+            .requestMatchers("/api/**").permitAll()
+            // 기타 모든 요청은 허용
+            .anyRequest().permitAll()
+        )
+        .csrf(csrf -> csrf.disable())
+        .httpBasic(httpBasic -> httpBasic.disable())
+        .formLogin(formLogin -> formLogin.disable());
+
+    return http.build();
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/controller/StorageController.java
+++ b/store/src/main/java/com/dorandoran/store/controller/StorageController.java
@@ -1,0 +1,296 @@
+package com.dorandoran.store.controller;
+
+import com.dorandoran.store.dto.request.BookmarkRequest;
+import com.dorandoran.store.dto.response.BookmarkResponse;
+import com.dorandoran.store.dto.response.StorageListResponse;
+import com.dorandoran.store.service.StorageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Storage Controller
+ * 보관함 API
+ */
+@RestController
+@RequestMapping("/api/store/bookmarks")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Storage", description = "보관함 API")
+public class StorageController {
+
+  private final StorageService storageService;
+
+  /**
+   * 표현 보관하기
+   */
+  @PostMapping
+  @Operation(summary = "표현 보관", description = "사용자가 표현과 AI 응답을 보관함에 저장")
+  public ResponseEntity<BookmarkResponse> saveBookmark(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "보관 요청 데이터", required = true)
+      @Valid @RequestBody BookmarkRequest request) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("POST /api/store/bookmarks - userId: {}", userId);
+
+    BookmarkResponse response = storageService.saveBookmark(userId, request);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  /**
+   * 보관함 전체 조회
+   */
+  @GetMapping
+  @Operation(summary = "보관함 전체 조회", description = "사용자의 보관함 전체 목록 조회")
+  public ResponseEntity<List<StorageListResponse>> getBookmarks(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks - userId: {}", userId);
+
+    List<StorageListResponse> response = storageService.getBookmarks(userId);
+
+    return ResponseEntity.ok(response);
+  }
+
+
+  /**
+   * 보관함 전체 조회 (페이징)
+   */
+  @GetMapping("/page")
+  @Operation(summary = "보관함 조회 (페이징)", description = "페이징된 보관함 목록 조회")
+  public ResponseEntity<Page<StorageListResponse>> getBookmarksPage(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+      Pageable pageable) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/page - userId: {}", userId);
+
+    Page<StorageListResponse> response = storageService.getBookmarks(userId, pageable);
+
+    return ResponseEntity.ok(response);
+  }
+
+//  /**
+//   * 방별 보관함 조회
+//   */
+//  @GetMapping("/chatroom/{chatroomId}")
+//  @Operation(summary = "방별 보관함 조회", description = "특정 채팅방의 보관함만 조회")
+//  public ResponseEntity<List<StorageListResponse>> getBookmarksByChatroom(
+//      @Parameter(description = "사용자 ID", required = true)
+//      @RequestHeader("X-User-Id") UUID userId,
+//
+//      @Parameter(description = "채팅방 ID", required = true)
+//      @PathVariable UUID chatroomId) {
+//
+//    log.info("GET /api/store/bookmarks/chatroom/{} - userId: {}", chatroomId, userId);
+//
+//    List<StorageListResponse> response = storageService.getBookmarksByChatroom(userId, chatroomId);
+//
+//    return ResponseEntity.ok(response);
+//  }
+
+  /**
+   * 챗봇 타입별 보관함 조회
+   */
+  @GetMapping("/bot-type/{botType}")
+  @Operation(summary = "챗봇 타입별 보관함 조회", description = "특정 챗봇 타입의 모든 보관함 조회")
+  public ResponseEntity<List<StorageListResponse>> getBookmarksByBotType(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "챗봇 타입 (friend, honey, coworker, senior)", required = true)
+      @PathVariable String botType) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/bot-type/{} - userId: {}", botType, userId);
+
+    // botType 유효성 검증
+    if (!botType.matches("^(friend|honey|coworker|senior)$")) {
+      log.warn("유효하지 않은 botType: {}", botType);
+      return ResponseEntity.badRequest().build();
+    }
+
+    List<StorageListResponse> response = storageService.getBookmarksByBotType(userId, botType);
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 보관함 삭제
+   */
+  @DeleteMapping("/{bookmarkId}")
+  @Operation(summary = "보관함 삭제", description = "보관함 항목 삭제 (소프트 삭제)")
+  public ResponseEntity<Void> deleteBookmark(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "보관함 ID", required = true)
+      @PathVariable UUID bookmarkId) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("DELETE /api/store/bookmarks/{} - userId: {}", bookmarkId, userId);
+
+    storageService.deleteBookmark(userId, bookmarkId);
+
+    return ResponseEntity.noContent().build();
+  }
+
+
+  /**
+   * 보관함 일괄 삭제
+   */
+  @DeleteMapping
+  @Operation(summary = "보관함 일괄 삭제", description = "여러 보관함 항목 한 번에 삭제")
+  public ResponseEntity<Void> deleteBookmarks(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "삭제할 보관함 ID 리스트", required = true)
+      @RequestBody List<UUID> bookmarkIds) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("DELETE /api/store/bookmarks - userId: {}, count: {}", userId, bookmarkIds.size());
+
+    storageService.deleteBookmarks(userId, bookmarkIds);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * 보관함 개수 조회
+   */
+  @GetMapping("/count")
+  @Operation(summary = "보관함 개수", description = "사용자의 보관함 항목 개수 조회")
+  public ResponseEntity<Long> countBookmarks(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/count - userId: {}", userId);
+
+    long count = storageService.countBookmarks(userId);
+
+    return ResponseEntity.ok(count);
+  }
+
+//  /**
+//   * 챗봇별 보관함 조회
+//   */
+//  @GetMapping("/chatbot/{chatbotId}")
+//  @Operation(summary = "챗봇별 보관함 조회", description = "특정 챗봇의 모든 보관함 조회 (여러 채팅방 포함)")
+//  public ResponseEntity<List<StorageListResponse>> getBookmarksByChatbot(
+//      @Parameter(description = "사용자 ID", required = true)
+//      @RequestHeader("X-User-Id") UUID userId,
+//
+//      @Parameter(description = "챗봇 ID", required = true)
+//      @PathVariable UUID chatbotId) {
+//
+//    log.info("GET /api/store/bookmarks/chatbot/{} - userId: {}", chatbotId, userId);
+//
+//    List<StorageListResponse> response = storageService.getBookmarksByChatbot(userId, chatbotId);
+//
+//    return ResponseEntity.ok(response);
+//  }
+
+  /**
+   * Cursor 기반 페이징 조회
+   */
+  @GetMapping("/cursor")
+  @Operation(summary = "보관함 조회 (Cursor 페이징)", description = "Cursor 기반 무한 스크롤용 페이징 조회")
+  public ResponseEntity<Page<StorageListResponse>> getBookmarksWithCursor(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "마지막 조회 ID (null이면 처음부터)")
+      @RequestParam(required = false) UUID lastId,
+
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+      Pageable pageable) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/cursor - userId: {}, lastId: {}", userId, lastId);
+
+    Page<StorageListResponse> response = storageService.getBookmarksWithCursor(userId, lastId, pageable);
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * X-User-Id 헤더 파싱
+   * @param userIdHeader X-User-Id 헤더 값
+   * @return UUID 또는 null
+   */
+  private UUID parseUserIdHeader(String userIdHeader) {
+    if (userIdHeader == null || userIdHeader.isBlank()) {
+      return null;
+    }
+    try {
+      return UUID.fromString(userIdHeader);
+    } catch (IllegalArgumentException e) {
+      log.warn("Invalid X-User-Id header format: {}", userIdHeader);
+      return null;
+    }
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/service/StorageService.java
+++ b/store/src/main/java/com/dorandoran/store/service/StorageService.java
@@ -1,0 +1,330 @@
+package com.dorandoran.store.service;
+
+import com.dorandoran.store.client.ChatServiceClient;
+import com.dorandoran.store.client.dto.ChatRoomDto;
+import com.dorandoran.store.dto.request.BookmarkRequest;
+import com.dorandoran.store.dto.response.BookmarkResponse;
+import com.dorandoran.store.dto.response.StorageListResponse;
+import com.dorandoran.store.entity.Store;
+import com.dorandoran.store.exception.BookmarkNotFoundException;
+import com.dorandoran.store.exception.DuplicateBookmarkException;
+import com.dorandoran.store.exception.UnauthorizedAccessException;
+import com.dorandoran.store.repository.StoreRepository;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Storage Service
+ * 보관함 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StorageService {
+
+  private final StoreRepository storeRepository;
+  private final ChatServiceClient chatServiceClient;  // 채팅방 정보 획득
+
+  /**
+   * 표현 보관하기
+   */
+  @Transactional
+  public BookmarkResponse saveBookmark(UUID userId, BookmarkRequest request) {
+    log.info("표현 보관 시작: userId={}, messageId={}", userId, request.getMessageId());
+
+    // 중복 체크
+    if (storeRepository.existsByUserIdAndMessageIdAndIsDeletedFalse(userId, request.getMessageId())) {
+      log.warn("중복 저장 시도: userId={}, messageId={}", userId, request.getMessageId());
+      throw new DuplicateBookmarkException("이미 보관함에 저장된 표현입니다");
+    }
+
+    // Store 엔티티 생성
+    Store store = Store.builder()
+        .userId(userId)
+        .messageId(request.getMessageId())
+        .chatroomId(request.getChatroomId())
+//        .chatbotId(request.getChatbotId())
+        .content(request.getContent())
+        .aiResponse(request.getAiResponse())
+        .botType(request.getBotType())
+        .isDeleted(false)
+        .build();
+
+    Store saved = storeRepository.save(store);
+    log.info("표현 보관 완료: storeId={}", saved.getId());
+
+    return BookmarkResponse.from(saved, "표현이 보관함에 저장되었습니다");
+  }
+
+  /**
+   * 보관함 전체 조회
+   */
+  @Transactional(readOnly = true)
+  public List<StorageListResponse> getBookmarks(UUID userId) {
+    log.info("보관함 전체 조회: userId={}", userId);
+
+    List<Store> stores = storeRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(userId);
+
+    if (stores.isEmpty()) {
+      log.info("보관함이 비어있음: userId={}", userId);
+    }
+
+    return stores.stream()
+        .map(store -> enrichWithChatroomName(store))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 보관함 전체 조회 (페이징)
+   */
+  @Transactional(readOnly = true)
+  public Page<StorageListResponse> getBookmarks(UUID userId, Pageable pageable) {
+    log.info("보관함 조회 (페이징): userId={}, page={}, size={}",
+        userId, pageable.getPageNumber(), pageable.getPageSize());
+
+    Page<Store> stores = storeRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, pageable);
+
+    return stores.map(store -> enrichWithChatroomName(store));
+  }
+
+//  /**
+//   * 방별 보관함 조회
+//   */
+//  @Transactional(readOnly = true)
+//  public List<StorageListResponse> getBookmarksByChatroom(UUID userId, UUID chatroomId) {
+//    log.info("방별 보관함 조회: userId={}, chatroomId={}", userId, chatroomId);
+//
+//    List<Store> stores = storeRepository
+//        .findByUserIdAndChatroomIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, chatroomId);
+//
+//    if (stores.isEmpty()) {
+//      log.info("해당 채팅방의 보관함이 비어있음: chatroomId={}", chatroomId);
+//    }
+//
+//    // 방별 조회는 같은 채팅방이므로 한 번만 조회
+//    String chatroomName = "Unknown";
+//    try {
+//      chatroomName = chatServiceClient.getChatRoom(chatroomId).getName();
+//    } catch (Exception e) {
+//      log.warn("채팅방 이름 조회 실패: chatroomId={}", chatroomId, e);
+//    }
+//
+//    final String finalChatroomName = chatroomName;
+//    return stores.stream()
+//        .map(store -> {
+//          StorageListResponse response = StorageListResponse.from(store);
+//          response.setChatroomNameFromClient(finalChatroomName);
+//          return response;
+//        })
+//        .collect(Collectors.toList());
+//  }
+//
+//  /**
+//   * 방별 보관함 조회 (페이징)
+//   */
+//  @Transactional(readOnly = true)
+//  public Page<StorageListResponse> getBookmarksByChatroom(UUID userId, UUID chatroomId, Pageable pageable) {
+//    log.info("방별 보관함 조회 (페이징): userId={}, chatroomId={}", userId, chatroomId);
+//
+//    Page<Store> stores = storeRepository
+//        .findByUserIdAndChatroomIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, chatroomId, pageable);
+//
+//    // 방별 조회는 같은 채팅방이므로 한 번만 조회
+//    String chatroomName = "Unknown";
+//    try {
+//      chatroomName = chatServiceClient.getChatRoom(chatroomId).getName();
+//    } catch (Exception e) {
+//      log.warn("채팅방 이름 조회 실패: chatroomId={}", chatroomId, e);
+//    }
+//
+//    final String finalChatroomName = chatroomName;
+//    return stores.map(store -> {
+//      StorageListResponse response = StorageListResponse.from(store);
+//      response.setChatroomNameFromClient(finalChatroomName);
+//      return response;
+//    });
+//  }
+
+  /**
+   * botType별 조회
+   */
+  @Transactional(readOnly = true)
+  public List<StorageListResponse> getBookmarksByBotType(UUID userId, String botType) {
+    log.info("챗봇 타입별 보관함 조회: userId={}, botType={}", userId, botType);
+
+    List<Store> stores = storeRepository
+        .findByUserIdAndBotTypeAndIsDeletedFalseOrderByCreatedAtDesc(userId, botType);
+
+    if (stores.isEmpty()) {
+      log.info("해당 챗봇 타입의 보관함이 비어있음: botType={}", botType);
+    }
+
+    return stores.stream()
+        .map(store -> enrichWithChatroomName(store))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Cursor 기반 페이징 조회
+   */
+  @Transactional(readOnly = true)
+  public Page<StorageListResponse> getBookmarksWithCursor(UUID userId, UUID lastId, Pageable pageable) {
+    log.info("Cursor 기반 보관함 조회: userId={}, lastId={}, size={}",
+        userId, lastId, pageable.getPageSize());
+
+    Page<Store> stores = storeRepository.findByUserIdWithCursor(userId, lastId, pageable);
+
+    return stores.map(store -> enrichWithChatroomName(store));
+  }
+
+  /**
+   * 보관함 삭제 (소프트 삭제)
+   */
+  @Transactional
+  public void deleteBookmark(UUID userId, UUID bookmarkId) {
+    log.info("보관함 삭제: userId={}, bookmarkId={}", userId, bookmarkId);
+
+    Store store = storeRepository.findById(bookmarkId)
+        .orElseThrow(() -> new BookmarkNotFoundException("보관함 항목을 찾을 수 없습니다"));
+
+    // 권한 확인
+    if (!store.getUserId().equals(userId)) {
+      log.warn("삭제 권한 없음: userId={}, storeUserId={}", userId, store.getUserId());
+      throw new UnauthorizedAccessException("삭제 권한이 없습니다");
+    }
+
+    // 이미 삭제됨
+    if (store.getIsDeleted()) {
+      log.warn("이미 삭제된 항목: bookmarkId={}", bookmarkId);
+      throw new IllegalStateException("이미 삭제된 항목입니다");
+    }
+
+    // 소프트 삭제
+    store.setIsDeleted(true);
+    store.setDeletedAt(LocalDateTime.now());
+    storeRepository.save(store);
+
+    log.info("보관함 삭제 완료: bookmarkId={}", bookmarkId);
+  }
+
+  /**
+   * 보관함 일괄 삭제 (소프트 삭제)
+   */
+  @Transactional
+  public void deleteBookmarks(UUID userId, List<UUID> bookmarkIds) {
+    log.info("보관함 일괄 삭제: userId={}, count={}", userId, bookmarkIds.size());
+
+    for (UUID bookmarkId : bookmarkIds) {
+      try {
+        deleteBookmark(userId, bookmarkId);
+      } catch (Exception e) {
+        log.error("삭제 실패: bookmarkId={}", bookmarkId, e);
+        // 실패해도 계속 진행
+      }
+    }
+
+    log.info("보관함 일괄 삭제 완료: userId={}", userId);
+  }
+
+  /**
+   * 보관함 개수 조회
+   */
+  @Transactional(readOnly = true)
+  public long countBookmarks(UUID userId) {
+    return storeRepository.countByUserIdAndIsDeletedFalse(userId);
+  }
+
+//  /**
+//   * 챗봇별 보관함 조회
+//   */
+//  @Transactional(readOnly = true)
+//  public List<StorageListResponse> getBookmarksByChatbot(UUID userId, UUID chatbotId) {
+//    log.info("챗봇별 보관함 조회: userId={}, chatbotId={}", userId, chatbotId);
+//
+//    List<Store> stores = storeRepository
+//        .findByUserIdAndChatbotIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, chatbotId);
+//
+//    if (stores.isEmpty()) {
+//      log.info("해당 챗봇의 보관함이 비어있음: chatbotId={}", chatbotId);
+//    }
+//
+//    return stores.stream()
+//        .map(store -> {
+//          StorageListResponse response = StorageListResponse.from(store);
+//          try {
+//            String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
+//            response.setChatroomNameFromClient(chatroomName);
+//          } catch (Exception e) {
+//            log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
+//            response.setChatroomNameFromClient("Unknown");
+//          }
+//          return response;
+//        })
+//        .collect(Collectors.toList());
+//  }
+
+  /**
+   * botType별 조회
+   * @param userId
+   * @param botType
+   * @return
+   */
+  @Transactional(readOnly = true)
+  public List<StorageListResponse> getBookmarksByBotType(UUID userId, String botType) {
+    log.info("챗봇 타입별 보관함 조회: userId={}, botType={}", userId, botType);
+
+    List<Store> stores = storeRepository
+        .findByUserIdAndBotTypeAndIsDeletedFalseOrderByCreatedAtDesc(userId, botType);
+
+    if (stores.isEmpty()) {
+      log.info("해당 챗봇 타입의 보관함이 비어있음: botType={}", botType);
+    }
+
+    return stores.stream()
+        .map(store -> {
+          StorageListResponse response = StorageListResponse.from(store);
+          try {
+            String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
+            response.setChatroomNameFromClient(chatroomName);
+          } catch (Exception e) {
+            log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
+            response.setChatroomNameFromClient("Unknown");
+          }
+          return response;
+        })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Cursor 기반 페이징 조회
+   */
+  @Transactional(readOnly = true)
+  public Page<StorageListResponse> getBookmarksWithCursor(UUID userId, UUID lastId, Pageable pageable) {
+    log.info("Cursor 기반 보관함 조회: userId={}, lastId={}, size={}",
+        userId, lastId, pageable.getPageSize());
+
+    Page<Store> stores = storeRepository.findByUserIdWithCursor(userId, lastId, pageable);
+
+    return stores.map(store -> {
+      StorageListResponse response = StorageListResponse.from(store);
+      try {
+        String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
+        response.setChatroomNameFromClient(chatroomName);
+      } catch (Exception e) {
+        log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
+        response.setChatroomNameFromClient("Unknown");
+      }
+      return response;
+    });
+  }
+}

--- a/store/src/main/resources/application.yml
+++ b/store/src/main/resources/application.yml
@@ -1,0 +1,65 @@
+spring:
+  application:
+    name: store-service
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/dorandoran
+    username: doran
+    password: doran
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_schema: store_schema
+
+  sql:
+    init:
+      mode: never
+
+server:
+  port: 8084
+
+# Actuator
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+
+# Logging
+logging:
+  level:
+    com.dorandoran.store: DEBUG
+    org.springframework.web: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+# Feign Client
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+        loggerLevel: FULL
+  chat-service:
+    url: ${FEIGN_CHAT_SERVICE_URL:http://localhost:8083}
+  circuitbreaker:
+    enabled: true
+
+# OpenAPI/Swagger
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->

- Chat, User, Auth 모듈 구현 상태 (2025.10.18 dev 브랜치)
- Store Service 기본 CRUD 구현 완료 (fix/store 브랜치)
- **Git 히스토리 정리로 인한 브랜치 분기 문제 발생**
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->

- Docker Compose 수정 store 일단 포함
- 사용자 인증 헤더(`X-User-Id`) 처리 강화
- Feign Client 예외 처리 세분화 (403, 503 대응)
- store 모듈 Security 수정
- **Git 히스토리 충돌 해결 및 브랜치 재구성**

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

### 1. 사용자 인증 및 권한 체크 강화
- **StorageController**: `X-User-Id` 헤더 처리 로직 추가
  - Security Context 우선, 헤더 fallback 방식
  - 모든 엔드포인트에 사용자 인증 적용
- **ChatServiceClient**: userId 파라미터 추가하여 Chat Service 권한 체크 연동
  - Chat Service에서 사용자별 채팅방 접근 권한 검증

### 2. Feign Client 예외 처리 세분화
- **StorageService.enrichWithChatroomName()**: 다양한 Feign 예외 상황별 대응
  - `FeignException.NotFound` (404): "Deleted Room" 반환
  - `FeignException.Forbidden` (403): "Forbidden" 반환
  - `FeignException.ServiceUnavailable` (503): "Unavailable" 반환
  - 일반 `FeignException`: "Unknown" 반환 + 로그 기록
- Circuit Breaker 패턴 적용 (Fallback 클래스)

### 3. Security 설정 수정
- **SecurityConfig**: Public API 패턴 불일치 문제 해결
  - `/api/store/users/**` → `/api/store/user/**`
  - `/api/store/auth/**` 패턴 추가
  - CORS 처리 로직 제거

### 4. Docker Compose 완전 통합
- **Store Service 컨테이너 추가**
  - 포트: 8084
  - 환경변수: FEIGN_CHAT_SERVICE_URL, DATASOURCE_URL
  - 의존성: shared-db, chat-service

### 5. 환경변수 기반 설정
- **Store Service application.yml**
  - `FEIGN_CHAT_SERVICE_URL` 환경변수 사용

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->

### Gateway Service 변경
- **HomeController**: Store Service 라우팅 정보 추가
  - `/api/store/**` 패턴 반환

### Git 히스토리 문제 해결
- **문제 상황**: 
  - dev 브랜치에서 히스토리 정리 (프로젝트 구조 정리 및 서브모듈 제거)
  - 기존 fix/store 브랜치와 공통 조상 사라짐
  - GitHub에서 "entirely different commit histories" 에러 발생
- **해결 방법**:
  - cherry-pick으로 Store Service 작업 커밋 8개만 선택적으로 적용
  - 히스토리 재구성: `origin/dev` 기반 → Store 작업 커밋들
  - 충돌 해결: 삭제된 파일들(modify/delete conflict) 수동 추가
- **영향**: 
  - 커밋 해시 변경 (기존 fix/store와 다름)
  - 추가적인 영향 있을 수 있음..

## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] **API 테스트** 
  - ✅ 채팅방 생성 (Chat Service) - 201 Created
  - ✅ 메시지 전송 (Chat Service) - 201 Created
  - ✅ 북마크 저장 (Store Service) - 201 Created
  - ✅ 북마크 전체 조회 - 200 OK
  - ✅ 페이징 조회 (Offset) - 200 OK
  - ✅ Cursor 페이징 조회 - 200 OK
  - ✅ 챗봇 타입별 조회 (friend) - 200 OK
  - ✅ 북마크 개수 조회 - 200 OK
  - ✅ 중복 저장 방지 - 409 Conflict
  - ✅ 북마크 삭제 - 204 No Content
  - ✅ 삭제 후 조회 확인 - 200 OK (빈 배열)
  - ✅ Feign Client 동작 확인 - chatroomName 정상 조회