### PR TITLE
Fix/store service

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -95,6 +95,26 @@ services:
       redis:
         condition: service_started
 
+  # Store Service
+  store-service:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.store
+    container_name: dd-store-service
+    ports: [ "8084:8084" ]
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://shared-db:5432/dorandoran
+      - SPRING_DATASOURCE_USERNAME=doran
+      - SPRING_DATASOURCE_PASSWORD=doran
+      - SPRING_JPA_HIBERNATE_DEFAULT_SCHEMA=store_schema
+      - FEIGN_CHAT_SERVICE_URL=http://chat-service:8083
+    depends_on:
+      shared-db:
+        condition: service_healthy
+      chat-service:
+        condition: service_started
+
   # Batch Service
   batch-service:
     build:

--- a/docker/scripts/init-shared-db.sql
+++ b/docker/scripts/init-shared-db.sql
@@ -423,6 +423,7 @@ CREATE TABLE store_schema.stores (
     message_id UUID NOT NULL,
     chatroom_id UUID NOT NULL,
     content TEXT NOT NULL,
+    corrected_content TEXT,
     ai_response JSONB NOT NULL,
     bot_type VARCHAR(20),
     is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
@@ -435,6 +436,7 @@ COMMENT ON TABLE store_schema.stores IS ''보관함 - 사용자가 저장한 표
 COMMENT ON COLUMN store_schema.stores.content IS ''표현 원본'';
 COMMENT ON COLUMN store_schema.stores.ai_response IS ''Multi-Agent AI 응답 (JSONB)'';
 COMMENT ON COLUMN store_schema.stores.bot_type IS ''챗봇 역할 (Honey, Coworker, Senior, Client)'';
+COMMENT ON COLUMN store_schema.stores.corrected_content IS '친밀도 Agent가 교정한 문장 (교정 없으면 NULL)';
 
 -- 인덱스
 CREATE UNIQUE INDEX idx_store_user_message

--- a/gateway/src/main/java/com/dorandoran/gateway/controller/HomeController.java
+++ b/gateway/src/main/java/com/dorandoran/gateway/controller/HomeController.java
@@ -27,7 +27,8 @@ public class HomeController {
             "auth", "/api/auth/**",
             "user", "/api/users/**",
             "chat", "/api/chat/**",
-            "batch", "/api/batch/**"
+            "batch", "/api/batch/**",
+            "store", "/api/store/**"
         ));
         return Mono.just(response);
     }

--- a/store/Dockerfile
+++ b/store/Dockerfile
@@ -1,0 +1,16 @@
+FROM gradle:8.5-jdk21 AS build
+WORKDIR /app
+COPY settings.gradle .
+COPY build.gradle .
+COPY common ./common
+COPY shared ./shared
+COPY store ./store
+RUN gradle :store:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/store/build/libs/*.jar app.jar
+EXPOSE 8084
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8084/actuator/health || exit 1
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+    id 'java'
+}
+
+dependencies {
+    implementation project(':shared')
+    implementation project(':common')
+
+    // Feign 클라이언트 (Chat Service 호출용)
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
+
+    // Circuit Breaker
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+
+    // Prometheus 메트릭
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // SpringDoc OpenAPI (Swagger)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // 데이터베이스
+    implementation 'org.postgresql:postgresql:42.7.4'
+
+    // 테스트
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
+
+    // Lombok은 common에서 제공, annotationProcessor만 필요
+    annotationProcessor 'org.projectlombok:lombok'
+}

--- a/store/src/main/java/com/dorandoran/store/StoreApplication.java
+++ b/store/src/main/java/com/dorandoran/store/StoreApplication.java
@@ -1,0 +1,26 @@
+package com.dorandoran.store;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * Store Service Application
+ * 보관함 서비스 - 사용자가 저장한 표현 관리
+ */
+@SpringBootApplication
+@EnableFeignClients // Feign Client 활성화 (Chat Service 호출용)
+@EnableJpaAuditing  // JPA Auditing 활성화 (CreatedDate, LastModifiedDate 자동 관리)
+public class StoreApplication {
+
+  /**
+   * Store Service 시작점
+   *
+   * @param args 커맨드 라인 인자
+   */
+  public static void main(String[] args) {
+    SpringApplication.run(StoreApplication.class, args);
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/client/ChatServiceClient.java
+++ b/store/src/main/java/com/dorandoran/store/client/ChatServiceClient.java
@@ -1,0 +1,33 @@
+package com.dorandoran.store.client;
+
+import com.dorandoran.store.client.dto.ChatRoomDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Chat Service Feign Client
+ * 채팅과 보관함 연결
+ */
+@FeignClient(
+    name = "chat-service",
+    url = "${feign.chat-service.url:http://localhost:8083}",
+    fallback = ChatServiceClientFallback.class
+)
+public interface ChatServiceClient {
+
+  /**
+   * 채팅방 정보 조회
+   * @param chatroomId 채팅방 ID
+   * @param userId 사용자 ID (권한 체크용)
+   * @return 채팅방 정보
+   */
+  @GetMapping("/api/chat/chatrooms/{chatroomId}")
+  ChatRoomDto getChatRoom(
+      @PathVariable("chatroomId") UUID chatroomId,
+      @RequestParam("userId") UUID userId
+  );
+}

--- a/store/src/main/java/com/dorandoran/store/client/ChatServiceClientFallback.java
+++ b/store/src/main/java/com/dorandoran/store/client/ChatServiceClientFallback.java
@@ -1,0 +1,28 @@
+package com.dorandoran.store.client;
+
+import com.dorandoran.store.client.dto.ChatRoomDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Chat Service Feign Client Fallback
+ * Circuit Breaker 패턴
+ */
+@Component
+@Slf4j
+public class ChatServiceClientFallback implements ChatServiceClient {
+
+  @Override
+  public ChatRoomDto getChatRoom(UUID chatroomId, UUID userId) {
+    log.warn("Chat Service 호출 실패 - Fallback 실행: chatroomId={}, userId={}",
+        chatroomId, userId);
+
+    // Fallback 응답: name = "Unknown"
+    return ChatRoomDto.builder()
+        .id(chatroomId)
+        .name("Unknown")
+        .build();
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/client/dto/ChatRoomDto.java
+++ b/store/src/main/java/com/dorandoran/store/client/dto/ChatRoomDto.java
@@ -1,0 +1,21 @@
+package com.dorandoran.store.client.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * Chat Service의 ChatRoom 응답 DTO
+ * 필요한 필드만 매핑
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomDto {
+  private UUID id;
+  private String name;
+}

--- a/store/src/main/java/com/dorandoran/store/config/OpenApiConfig.java
+++ b/store/src/main/java/com/dorandoran/store/config/OpenApiConfig.java
@@ -1,0 +1,83 @@
+package com.dorandoran.store.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * OpenAPI (Swagger) 설정
+ *
+ * <p>Store Service의 API 문서를 자동 생성하기 위한 설정</p>
+ *
+ * <h3>접근 방법:</h3>
+ * <ul>
+ *   <li>Swagger UI: http://localhost:8084/swagger-ui.html</li>
+ *   <li>API Docs: http://localhost:8084/api-docs</li>
+ * </ul>
+ *
+ * <h3>주요 기능:</h3>
+ * <ul>
+ *   <li>API 문서 자동 생성</li>
+ *   <li>Try it out 기능 (API 테스트)</li>
+ *   <li>스키마 정의 자동화</li>
+ * </ul>
+ *
+ * @author DoranDoran Team
+ * @version 1.0
+ * @since 2025-10-11
+ */
+@Configuration
+public class OpenApiConfig {
+
+  /**
+   * OpenAPI 문서 설정
+   *
+   * <p>Store Service의 API 정보, 서버 정보, 라이센스 등을 정의</p>
+   *
+   * @return OpenAPI 설정 객체
+   */
+  @Bean
+  public OpenAPI storeServiceOpenAPI() {
+    return new OpenAPI()
+        // API 기본 정보
+        .info(new Info()
+            .title("DoranDoran Store Service API")  // API 제목
+            .description("보관함 서비스 - 사용자가 저장한 표현 관리")  // API 설명
+            .version("v1.0.0")  // API 버전
+
+            // 연락처 정보
+            .contact(new Contact()
+                .name("DoranDoran Team")
+                .email("support@dorandoran.com")
+                .url("https://dorandoran.com"))
+
+            // 라이센스 정보
+            .license(new License()
+                .name("Apache 2.0")
+                .url("https://www.apache.org/licenses/LICENSE-2.0.html")))
+
+        // 서버 정보 (여러 환경)
+        .servers(List.of(
+            // 로컬 개발 서버
+            new Server()
+                .url("http://localhost:8084")
+                .description("로컬 개발 환경"),
+
+            // Docker 환경
+            new Server()
+                .url("http://localhost:8084")
+                .description("Docker 환경"),
+
+            // Gateway를 통한 접근
+            new Server()
+                .url("http://localhost:8080/store")
+                .description("API Gateway 경유")
+        ));
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/config/SecurityConfig.java
+++ b/store/src/main/java/com/dorandoran/store/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.dorandoran.store.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Security 설정
+ * Store Service는 내부 MSA 서비스로, API Gateway에서 이미 인증을 처리함 - 기존 CORS 처리 코드 삭제
+ * 전달된 X-User-Id 헤더만 검증하고 Security Context는 사용하지 않음
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .authorizeHttpRequests(authz -> authz
+            // Swagger UI 접근 허용
+            .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
+                "/api-docs/**").permitAll()
+            // Actuator 엔드포인트 허용
+            .requestMatchers("/actuator/**").permitAll()
+            // API 엔드포인트는 MSA 내부 통신이므로 허용 (API Gateway가 인증 처리)
+            .requestMatchers("/api/**").permitAll()
+            // 기타 모든 요청은 허용
+            .anyRequest().permitAll()
+        )
+        .csrf(csrf -> csrf.disable())
+        .httpBasic(httpBasic -> httpBasic.disable())
+        .formLogin(formLogin -> formLogin.disable());
+
+    return http.build();
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/config/WebMvcConfig.java
+++ b/store/src/main/java/com/dorandoran/store/config/WebMvcConfig.java
@@ -1,0 +1,88 @@
+package com.dorandoran.store.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web MVC 설정
+ *
+ * <p>Store Service의 웹 계층 설정 (CORS, Interceptor 등)</p>
+ *
+ * <h3>주요 설정:</h3>
+ * <ul>
+ *   <li>CORS: 프론트엔드와의 통신 허용</li>
+ *   <li>Interceptor: HMAC 인증 (선택사항)</li>
+ * </ul>
+ *
+ * @author DoranDoran Team
+ * @version 1.0
+ * @since 2025-10-11
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+  // HmacAuthInterceptor는 필요 시 주입
+  // private final HmacAuthInterceptor hmacAuthInterceptor;
+
+  /**
+   * CORS 설정
+   *
+   * <p>프론트엔드(React 등)와의 크로스 도메인 통신을 허용</p>
+   *
+   * <h3>허용 항목:</h3>
+   * <ul>
+   *   <li>Origin: localhost:3000 (개발), 운영 도메인</li>
+   *   <li>Method: GET, POST, PUT, DELETE, OPTIONS</li>
+   *   <li>Header: 모든 헤더 허용</li>
+   *   <li>Credentials: 쿠키/인증 정보 허용</li>
+   * </ul>
+   *
+   * @param registry CORS 레지스트리
+   */
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/api/**")  // /api/** 경로에 대해 CORS 허용
+        .allowedOrigins(
+            "http://localhost:3000",      // React 개발 서버
+            "http://localhost:8080",      // API Gateway
+            "https://dorandoran.com"      // 운영 도메인
+        )
+        .allowedMethods(
+            "GET",     // 조회
+            "POST",    // 생성
+            "PUT",     // 수정
+            "DELETE",  // 삭제
+            "OPTIONS"  // Preflight
+        )
+        .allowedHeaders("*")        // 모든 헤더 허용
+        .allowCredentials(true)     // 쿠키/인증 정보 허용
+        .maxAge(3600);              // Preflight 캐시 시간 (1시간)
+  }
+
+  /**
+   * Interceptor 설정
+   *
+   * <p>HMAC 인증 인터셉터를 등록 (선택사항)</p>
+   *
+   * <h3>인터셉터 역할:</h3>
+   * <ul>
+   *   <li>서비스 간 통신 시 HMAC 서명 검증</li>
+   *   <li>API Gateway에서 오는 요청 검증</li>
+   * </ul>
+   *
+   * @param registry 인터셉터 레지스트리
+   */
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    // HMAC 인증이 필요한 경우 활성화
+    // registry.addInterceptor(hmacAuthInterceptor)
+    //         .addPathPatterns("/api/**")  // 모든 API 경로
+    //         .excludePathPatterns(
+    //                 "/actuator/**",      // Actuator 제외
+    //                 "/swagger-ui/**",    // Swagger UI 제외
+    //                 "/api-docs/**"       // API Docs 제외
+    //         );
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/controller/StorageController.java
+++ b/store/src/main/java/com/dorandoran/store/controller/StorageController.java
@@ -1,0 +1,296 @@
+package com.dorandoran.store.controller;
+
+import com.dorandoran.store.dto.request.BookmarkRequest;
+import com.dorandoran.store.dto.response.BookmarkResponse;
+import com.dorandoran.store.dto.response.StorageListResponse;
+import com.dorandoran.store.service.StorageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Storage Controller
+ * 보관함 API
+ */
+@RestController
+@RequestMapping("/api/store/bookmarks")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Storage", description = "보관함 API")
+public class StorageController {
+
+  private final StorageService storageService;
+
+  /**
+   * 표현 보관하기
+   */
+  @PostMapping
+  @Operation(summary = "표현 보관", description = "사용자가 표현과 AI 응답을 보관함에 저장")
+  public ResponseEntity<BookmarkResponse> saveBookmark(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "보관 요청 데이터", required = true)
+      @Valid @RequestBody BookmarkRequest request) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("POST /api/store/bookmarks - userId: {}", userId);
+
+    BookmarkResponse response = storageService.saveBookmark(userId, request);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  /**
+   * 보관함 전체 조회
+   */
+  @GetMapping
+  @Operation(summary = "보관함 전체 조회", description = "사용자의 보관함 전체 목록 조회")
+  public ResponseEntity<List<StorageListResponse>> getBookmarks(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks - userId: {}", userId);
+
+    List<StorageListResponse> response = storageService.getBookmarks(userId);
+
+    return ResponseEntity.ok(response);
+  }
+
+
+  /**
+   * 보관함 전체 조회 (페이징)
+   */
+  @GetMapping("/page")
+  @Operation(summary = "보관함 조회 (페이징)", description = "페이징된 보관함 목록 조회")
+  public ResponseEntity<Page<StorageListResponse>> getBookmarksPage(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+      Pageable pageable) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/page - userId: {}", userId);
+
+    Page<StorageListResponse> response = storageService.getBookmarks(userId, pageable);
+
+    return ResponseEntity.ok(response);
+  }
+
+//  /**
+//   * 방별 보관함 조회
+//   */
+//  @GetMapping("/chatroom/{chatroomId}")
+//  @Operation(summary = "방별 보관함 조회", description = "특정 채팅방의 보관함만 조회")
+//  public ResponseEntity<List<StorageListResponse>> getBookmarksByChatroom(
+//      @Parameter(description = "사용자 ID", required = true)
+//      @RequestHeader("X-User-Id") UUID userId,
+//
+//      @Parameter(description = "채팅방 ID", required = true)
+//      @PathVariable UUID chatroomId) {
+//
+//    log.info("GET /api/store/bookmarks/chatroom/{} - userId: {}", chatroomId, userId);
+//
+//    List<StorageListResponse> response = storageService.getBookmarksByChatroom(userId, chatroomId);
+//
+//    return ResponseEntity.ok(response);
+//  }
+
+  /**
+   * 챗봇 타입별 보관함 조회
+   */
+  @GetMapping("/bot-type/{botType}")
+  @Operation(summary = "챗봇 타입별 보관함 조회", description = "특정 챗봇 타입의 모든 보관함 조회")
+  public ResponseEntity<List<StorageListResponse>> getBookmarksByBotType(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "챗봇 타입 (friend, honey, coworker, senior)", required = true)
+      @PathVariable String botType) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/bot-type/{} - userId: {}", botType, userId);
+
+    // botType 유효성 검증
+    if (!botType.matches("^(friend|honey|coworker|senior)$")) {
+      log.warn("유효하지 않은 botType: {}", botType);
+      return ResponseEntity.badRequest().build();
+    }
+
+    List<StorageListResponse> response = storageService.getBookmarksByBotType(userId, botType);
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 보관함 삭제
+   */
+  @DeleteMapping("/{bookmarkId}")
+  @Operation(summary = "보관함 삭제", description = "보관함 항목 삭제 (소프트 삭제)")
+  public ResponseEntity<Void> deleteBookmark(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "보관함 ID", required = true)
+      @PathVariable UUID bookmarkId) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("DELETE /api/store/bookmarks/{} - userId: {}", bookmarkId, userId);
+
+    storageService.deleteBookmark(userId, bookmarkId);
+
+    return ResponseEntity.noContent().build();
+  }
+
+
+  /**
+   * 보관함 일괄 삭제
+   */
+  @DeleteMapping
+  @Operation(summary = "보관함 일괄 삭제", description = "여러 보관함 항목 한 번에 삭제")
+  public ResponseEntity<Void> deleteBookmarks(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "삭제할 보관함 ID 리스트", required = true)
+      @RequestBody List<UUID> bookmarkIds) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("DELETE /api/store/bookmarks - userId: {}, count: {}", userId, bookmarkIds.size());
+
+    storageService.deleteBookmarks(userId, bookmarkIds);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * 보관함 개수 조회
+   */
+  @GetMapping("/count")
+  @Operation(summary = "보관함 개수", description = "사용자의 보관함 항목 개수 조회")
+  public ResponseEntity<Long> countBookmarks(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/count - userId: {}", userId);
+
+    long count = storageService.countBookmarks(userId);
+
+    return ResponseEntity.ok(count);
+  }
+
+//  /**
+//   * 챗봇별 보관함 조회
+//   */
+//  @GetMapping("/chatbot/{chatbotId}")
+//  @Operation(summary = "챗봇별 보관함 조회", description = "특정 챗봇의 모든 보관함 조회 (여러 채팅방 포함)")
+//  public ResponseEntity<List<StorageListResponse>> getBookmarksByChatbot(
+//      @Parameter(description = "사용자 ID", required = true)
+//      @RequestHeader("X-User-Id") UUID userId,
+//
+//      @Parameter(description = "챗봇 ID", required = true)
+//      @PathVariable UUID chatbotId) {
+//
+//    log.info("GET /api/store/bookmarks/chatbot/{} - userId: {}", chatbotId, userId);
+//
+//    List<StorageListResponse> response = storageService.getBookmarksByChatbot(userId, chatbotId);
+//
+//    return ResponseEntity.ok(response);
+//  }
+
+  /**
+   * Cursor 기반 페이징 조회
+   */
+  @GetMapping("/cursor")
+  @Operation(summary = "보관함 조회 (Cursor 페이징)", description = "Cursor 기반 무한 스크롤용 페이징 조회")
+  public ResponseEntity<Page<StorageListResponse>> getBookmarksWithCursor(
+      @Parameter(description = "사용자 ID", required = true)
+      @RequestHeader(value = "X-User-Id", required = false) String userIdHeader,
+
+      @Parameter(description = "마지막 조회 ID (null이면 처음부터)")
+      @RequestParam(required = false) UUID lastId,
+
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+      Pageable pageable) {
+
+    UUID userId = parseUserIdHeader(userIdHeader);
+    if (userId == null) {
+      log.warn("X-User-Id header is missing or invalid");
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
+    log.info("GET /api/store/bookmarks/cursor - userId: {}, lastId: {}", userId, lastId);
+
+    Page<StorageListResponse> response = storageService.getBookmarksWithCursor(userId, lastId, pageable);
+
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * X-User-Id 헤더 파싱
+   * @param userIdHeader X-User-Id 헤더 값
+   * @return UUID 또는 null
+   */
+  private UUID parseUserIdHeader(String userIdHeader) {
+    if (userIdHeader == null || userIdHeader.isBlank()) {
+      return null;
+    }
+    try {
+      return UUID.fromString(userIdHeader);
+    } catch (IllegalArgumentException e) {
+      log.warn("Invalid X-User-Id header format: {}", userIdHeader);
+      return null;
+    }
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/dto/AiResponse.java
+++ b/store/src/main/java/com/dorandoran/store/dto/AiResponse.java
@@ -1,0 +1,63 @@
+package com.dorandoran.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Multi-Agent AI 응답 DTO
+ * PostgreSQL JSONB 컬럼에 저장
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AiResponse {
+
+  // 친밀도 레벨 (Close, Casual, Friendly)
+  private String intimacyLevel;
+
+  // AI 설명/피드백
+  private String description;
+
+  // 번역 정보
+  private Translation translation;
+
+  // 어려운 단어 설명들
+  private List<VocabularyItem> vocabulary;
+
+  // 교정 내용들
+  private List<String> corrections;
+
+  /**
+   * 번역 정보
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class Translation {
+    private String english;
+    private String pronunciation;
+  }
+
+  /**
+   * 어려운 단어 설명
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class VocabularyItem {
+    private String word;
+    private String pronunciation;
+    private String explanation;
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/dto/request/BookmarkRequest.java
+++ b/store/src/main/java/com/dorandoran/store/dto/request/BookmarkRequest.java
@@ -32,6 +32,9 @@ public class BookmarkRequest {
   @NotNull(message = "표현 내용은 필수입니다")
   private String content;
 
+  // 교정된 메시지
+  private String correctedContent;
+
   // Multi-Agent AI 응답 (필수)
   @NotNull(message = "AI 응답은 필수입니다")
   private AiResponse aiResponse;

--- a/store/src/main/java/com/dorandoran/store/dto/request/BookmarkRequest.java
+++ b/store/src/main/java/com/dorandoran/store/dto/request/BookmarkRequest.java
@@ -1,0 +1,42 @@
+package com.dorandoran.store.dto.request;
+
+import com.dorandoran.store.dto.AiResponse;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * 표현 보관 요청 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkRequest {
+
+  // 메시지 ID (필수)
+  @NotNull(message = "메시지 ID는 필수입니다")
+  private UUID messageId;
+
+  // 채팅방 ID (필수)
+  @NotNull(message = "채팅방 ID는 필수입니다")
+  private UUID chatroomId;
+
+  // 표현 원본 (필수)
+  @NotNull(message = "표현 내용은 필수입니다")
+  private String content;
+
+  // Multi-Agent AI 응답 (필수)
+  @NotNull(message = "AI 응답은 필수입니다")
+  private AiResponse aiResponse;
+
+  @NotBlank(message = "챗봇 타입은 필수입니다")
+  @Pattern(regexp = "^(friend|honey|coworker|senior)$", message = "챗봇 타입은 friend, honey, coworker, senior 중 하나여야 합니다")
+  private String botType;
+}

--- a/store/src/main/java/com/dorandoran/store/dto/response/BookmarkResponse.java
+++ b/store/src/main/java/com/dorandoran/store/dto/response/BookmarkResponse.java
@@ -1,0 +1,44 @@
+package com.dorandoran.store.dto.response;
+
+import com.dorandoran.store.dto.AiResponse;
+import com.dorandoran.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 표현 보관 응답 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkResponse {
+
+  private UUID id;
+  private UUID messageId;
+  private UUID chatroomId;
+  private String content;
+  private AiResponse aiResponse;
+  private String botType;
+  private LocalDateTime createdAt;
+  private String message;
+
+  // Entity -> DTO 변환
+  public static BookmarkResponse from(Store store, String message) {
+    return BookmarkResponse.builder()
+        .id(store.getId())
+        .messageId(store.getMessageId())
+        .chatroomId(store.getChatroomId())
+        .content(store.getContent())
+        .aiResponse(store.getAiResponse())
+        .botType(store.getBotType())
+        .createdAt(store.getCreatedAt())
+        .message(message)
+        .build();
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/dto/response/BookmarkResponse.java
+++ b/store/src/main/java/com/dorandoran/store/dto/response/BookmarkResponse.java
@@ -23,6 +23,7 @@ public class BookmarkResponse {
   private UUID messageId;
   private UUID chatroomId;
   private String content;
+  private String correctedContent;
   private AiResponse aiResponse;
   private String botType;
   private LocalDateTime createdAt;
@@ -35,6 +36,7 @@ public class BookmarkResponse {
         .messageId(store.getMessageId())
         .chatroomId(store.getChatroomId())
         .content(store.getContent())
+        .correctedContent(store.getCorrectedContent())
         .aiResponse(store.getAiResponse())
         .botType(store.getBotType())
         .createdAt(store.getCreatedAt())

--- a/store/src/main/java/com/dorandoran/store/dto/response/ErrorResponse.java
+++ b/store/src/main/java/com/dorandoran/store/dto/response/ErrorResponse.java
@@ -1,0 +1,57 @@
+package com.dorandoran.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 에러 응답 DTO
+ * 모든 에러를 통일된 형식으로 응답
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+  // 타임스탬프
+  @Builder.Default
+  private LocalDateTime timestamp = LocalDateTime.now();
+
+  // HTTP 상태 코드
+  private int status;
+
+  // 에러 코드 (커스텀)
+  private String code;
+
+  // 에러 메시지
+  private String message;
+
+  // 에러 상세 설명
+  private String detail;
+
+  // 요청 경로
+  private String path;
+
+  // 유효성 검증 에러들 (Validation)
+  private List<FieldError> errors;
+
+  /**
+   * 필드별 유효성 검증 에러
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class FieldError {
+    private String field;
+    private String message;
+    private Object rejectedValue;
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/dto/response/StorageListResponse.java
+++ b/store/src/main/java/com/dorandoran/store/dto/response/StorageListResponse.java
@@ -24,6 +24,7 @@ public class StorageListResponse {
   private UUID chatroomId;
   private String chatroomName;  // Chat Service에서 조회 (Feign)
   private String content;
+  private String correctedContent;
   private AiResponse aiResponse;
   private String botType;
   private LocalDateTime createdAt;
@@ -35,6 +36,7 @@ public class StorageListResponse {
         .messageId(store.getMessageId())
         .chatroomId(store.getChatroomId())
         .content(store.getContent())
+        .correctedContent(store.getCorrectedContent())
         .aiResponse(store.getAiResponse())
         .botType(store.getBotType())
         .createdAt(store.getCreatedAt())

--- a/store/src/main/java/com/dorandoran/store/dto/response/StorageListResponse.java
+++ b/store/src/main/java/com/dorandoran/store/dto/response/StorageListResponse.java
@@ -1,0 +1,48 @@
+package com.dorandoran.store.dto.response;
+
+import com.dorandoran.store.dto.AiResponse;
+import com.dorandoran.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 보관함 목록 응답 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StorageListResponse {
+
+  private UUID id;
+  private UUID messageId;
+  private UUID chatroomId;
+  private String chatroomName;  // Chat Service에서 조회 (Feign)
+  private String content;
+  private AiResponse aiResponse;
+  private String botType;
+  private LocalDateTime createdAt;
+
+  // Entity -> DTO 변환
+  public static StorageListResponse from(Store store) {
+    return StorageListResponse.builder()
+        .id(store.getId())
+        .messageId(store.getMessageId())
+        .chatroomId(store.getChatroomId())
+        .content(store.getContent())
+        .aiResponse(store.getAiResponse())
+        .botType(store.getBotType())
+        .createdAt(store.getCreatedAt())
+        .build();
+  }
+
+  // Chatroom 이름 설정 (Feign Client 조회 후)
+  public void setChatroomNameFromClient(String name) {
+    this.chatroomName = name;
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/entity/Store.java
+++ b/store/src/main/java/com/dorandoran/store/entity/Store.java
@@ -56,6 +56,9 @@ public class Store {
   @Column(name = "content", columnDefinition = "text", nullable = false)
   private String content;
 
+  @Column(name = "corrected_content", columnDefinition = "text")
+  private String correctedContent;  // IntimacyAgent가 교정한 문장
+
   // Multi-Agent AI 응답 (JSONB)
   @Column(name = "ai_response", columnDefinition = "jsonb", nullable = false)
   @JdbcTypeCode(SqlTypes.JSON)

--- a/store/src/main/java/com/dorandoran/store/entity/Store.java
+++ b/store/src/main/java/com/dorandoran/store/entity/Store.java
@@ -1,0 +1,84 @@
+package com.dorandoran.store.entity;
+
+import com.dorandoran.store.dto.AiResponse;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Store Entity - 보관함
+ * 사용자가 저장한 표현과 AI 응답을 관리
+ */
+@Entity
+@Table(
+    name = "stores",
+    schema = "store_schema",
+    indexes = {
+        @Index(name = "idx_store_user_message", columnList = "user_id, message_id", unique = true),
+        @Index(name = "idx_store_user_created", columnList = "user_id, created_at"),
+        @Index(name = "idx_store_chatroom", columnList = "chatroom_id, created_at")
+    }
+)
+@EntityListeners(AuditingEntityListener.class)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Store {
+
+  // PK
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(name = "id", updatable = false, nullable = false)
+  private UUID id;
+
+  // 관계 (MSA 원칙: UUID만 저장, FK 없음)
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @Column(name = "message_id", nullable = false)
+  private UUID messageId;
+
+  @Column(name = "chatroom_id", nullable = false)
+  private UUID chatroomId;
+
+  // 표현 원본
+  @Column(name = "content", columnDefinition = "text", nullable = false)
+  private String content;
+
+  // Multi-Agent AI 응답 (JSONB)
+  @Column(name = "ai_response", columnDefinition = "jsonb", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private AiResponse aiResponse;
+
+  // 챗봇 역할 (friend, honey, coworker, senior)
+  @Column(name = "bot_type", length = 20, nullable = false)
+  private String botType;
+
+  // 소프트 삭제
+  @Column(name = "is_deleted", nullable = false)
+  @Builder.Default
+  private Boolean isDeleted = false;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  // 타임스탬프
+  @CreatedDate
+  @Column(name = "created_at", updatable = false, nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+}

--- a/store/src/main/java/com/dorandoran/store/exception/BookmarkNotFoundException.java
+++ b/store/src/main/java/com/dorandoran/store/exception/BookmarkNotFoundException.java
@@ -1,0 +1,15 @@
+package com.dorandoran.store.exception;
+
+/**
+ * 보관함 항목을 찾을 수 없을 때 발생하는 예외
+ */
+public class BookmarkNotFoundException extends RuntimeException {
+
+  public BookmarkNotFoundException(String message) {
+    super(message);
+  }
+
+  public BookmarkNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/exception/DuplicateBookmarkException.java
+++ b/store/src/main/java/com/dorandoran/store/exception/DuplicateBookmarkException.java
@@ -1,0 +1,15 @@
+package com.dorandoran.store.exception;
+
+/**
+ * 중복 저장 시도 시 발생하는 예외
+ */
+public class DuplicateBookmarkException extends RuntimeException {
+
+  public DuplicateBookmarkException(String message) {
+    super(message);
+  }
+
+  public DuplicateBookmarkException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/exception/GlobalExceptionHandler.java
+++ b/store/src/main/java/com/dorandoran/store/exception/GlobalExceptionHandler.java
@@ -1,0 +1,175 @@
+package com.dorandoran.store.exception;
+
+import com.dorandoran.store.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 전역 예외 핸들러
+ * 모든 예외를 통일된 형식으로 응답
+ */
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+  /**
+   * 보관함 항목을 찾을 수 없음 (404)
+   */
+  @ExceptionHandler(BookmarkNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleBookmarkNotFound(
+      BookmarkNotFoundException ex,
+      HttpServletRequest request) {
+
+    log.error("BookmarkNotFoundException: {}", ex.getMessage());
+
+    ErrorResponse error = ErrorResponse.builder()
+        .status(HttpStatus.NOT_FOUND.value())
+        .code("BOOKMARK_NOT_FOUND")
+        .message(ex.getMessage())
+        .path(request.getRequestURI())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+  }
+
+  /**
+   * 중복 저장 시도 (409)
+   */
+  @ExceptionHandler(DuplicateBookmarkException.class)
+  public ResponseEntity<ErrorResponse> handleDuplicateBookmark(
+      DuplicateBookmarkException ex,
+      HttpServletRequest request) {
+
+    log.error("DuplicateBookmarkException: {}", ex.getMessage());
+
+    ErrorResponse error = ErrorResponse.builder()
+        .status(HttpStatus.CONFLICT.value())
+        .code("DUPLICATE_BOOKMARK")
+        .message(ex.getMessage())
+        .path(request.getRequestURI())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+  }
+
+  /**
+   * 권한 없는 접근 (403)
+   */
+  @ExceptionHandler(UnauthorizedAccessException.class)
+  public ResponseEntity<ErrorResponse> handleUnauthorizedAccess(
+      UnauthorizedAccessException ex,
+      HttpServletRequest request) {
+
+    log.error("UnauthorizedAccessException: {}", ex.getMessage());
+
+    ErrorResponse error = ErrorResponse.builder()
+        .status(HttpStatus.FORBIDDEN.value())
+        .code("UNAUTHORIZED_ACCESS")
+        .message(ex.getMessage())
+        .path(request.getRequestURI())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+  }
+
+  /**
+   * 잘못된 요청 (400)
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalArgument(
+      IllegalArgumentException ex,
+      HttpServletRequest request) {
+
+    log.error("IllegalArgumentException: {}", ex.getMessage());
+
+    ErrorResponse error = ErrorResponse.builder()
+        .status(HttpStatus.BAD_REQUEST.value())
+        .code("INVALID_REQUEST")
+        .message(ex.getMessage())
+        .path(request.getRequestURI())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+  }
+
+  /**
+   * 잘못된 상태 (400)
+   */
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalState(
+      IllegalStateException ex,
+      HttpServletRequest request) {
+
+    log.error("IllegalStateException: {}", ex.getMessage());
+
+    ErrorResponse error = ErrorResponse.builder()
+        .status(HttpStatus.BAD_REQUEST.value())
+        .code("INVALID_STATE")
+        .message(ex.getMessage())
+        .path(request.getRequestURI())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+  }
+
+  /**
+   * 유효성 검증 실패 (400)
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponse> handleValidationError(
+      MethodArgumentNotValidException ex,
+      HttpServletRequest request) {
+
+    log.error("MethodArgumentNotValidException: {}", ex.getMessage());
+
+    BindingResult bindingResult = ex.getBindingResult();
+
+    List<ErrorResponse.FieldError> fieldErrors = bindingResult.getFieldErrors().stream()
+        .map(fieldError -> ErrorResponse.FieldError.builder()
+            .field(fieldError.getField())
+            .message(fieldError.getDefaultMessage())
+            .rejectedValue(fieldError.getRejectedValue())
+            .build())
+        .collect(Collectors.toList());
+
+    ErrorResponse error = ErrorResponse.builder()
+        .status(HttpStatus.BAD_REQUEST.value())
+        .code("VALIDATION_ERROR")
+        .message("유효성 검증 실패")
+        .path(request.getRequestURI())
+        .errors(fieldErrors)
+        .build();
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+  }
+
+  /**
+   * 예상치 못한 에러 (500)
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGenericException(
+      Exception ex,
+      HttpServletRequest request) {
+
+    log.error("Unexpected Exception: ", ex);
+
+    ErrorResponse error = ErrorResponse.builder()
+        .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+        .code("INTERNAL_SERVER_ERROR")
+        .message("서버 내부 오류가 발생했습니다")
+        .detail(ex.getMessage())
+        .path(request.getRequestURI())
+        .build();
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/exception/UnauthorizedAccessException.java
+++ b/store/src/main/java/com/dorandoran/store/exception/UnauthorizedAccessException.java
@@ -1,0 +1,15 @@
+package com.dorandoran.store.exception;
+
+/**
+ * 권한 없는 접근 시 발생하는 예외
+ */
+public class UnauthorizedAccessException extends RuntimeException {
+
+  public UnauthorizedAccessException(String message) {
+    super(message);
+  }
+
+  public UnauthorizedAccessException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/repository/StoreRepository.java
+++ b/store/src/main/java/com/dorandoran/store/repository/StoreRepository.java
@@ -1,0 +1,70 @@
+package com.dorandoran.store.repository;
+
+import com.dorandoran.store.entity.Store;
+import feign.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Store Repository
+ */
+@Repository
+public interface StoreRepository extends JpaRepository<Store, UUID> {
+
+  // 사용자별 전체 조회
+  List<Store> findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(UUID userId);
+
+  // 사용자별 전체 조회 (페이징)
+  Page<Store> findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(UUID userId, Pageable pageable);
+
+//  // 방별 조회
+//  List<Store> findByUserIdAndChatroomIdAndIsDeletedFalseOrderByCreatedAtDesc(UUID userId, UUID chatroomId);
+//
+//  // 방별 조회 (페이징)
+//  Page<Store> findByUserIdAndChatroomIdAndIsDeletedFalseOrderByCreatedAtDesc(
+//      UUID userId, UUID chatroomId, Pageable pageable
+//  );
+
+  // 중복 저장 확인
+  boolean existsByUserIdAndMessageIdAndIsDeletedFalse(UUID userId, UUID messageId);
+
+  // 특정 보관함 조회
+  Optional<Store> findByUserIdAndMessageIdAndIsDeletedFalse(UUID userId, UUID messageId);
+
+  // 보관함 개수
+  long countByUserIdAndIsDeletedFalse(UUID userId);
+
+  /**
+   * 챗봇별 보관함 조회
+   */
+//  List<Store> findByUserIdAndChatbotIdAndIsDeletedFalseOrderByCreatedAtDesc(UUID userId, UUID chatbotId);
+
+  /**
+   * 챗봇 타입 별 보관함 조회
+   * @param userId
+   * @param botType
+   * @return
+   */
+  List<Store> findByUserIdAndBotTypeAndIsDeletedFalseOrderByCreatedAtDesc(UUID userId, String botType);
+
+
+  /**
+   * Cursor 기반 페이징 조회
+   * @param userId 사용자 ID
+   * @param lastId 마지막 조회 ID (null이면 처음부터)
+   * @param pageable 페이지 정보
+   */
+  @Query("SELECT s FROM Store s WHERE s.userId = :userId AND s.isDeleted = false " +
+      "AND (:lastId IS NULL OR s.id < :lastId) " +
+      "ORDER BY s.createdAt DESC")
+  Page<Store> findByUserIdWithCursor(@Param("userId") UUID userId,
+      @Param("lastId") UUID lastId,
+      Pageable pageable);
+}

--- a/store/src/main/java/com/dorandoran/store/service/StorageService.java
+++ b/store/src/main/java/com/dorandoran/store/service/StorageService.java
@@ -1,0 +1,330 @@
+package com.dorandoran.store.service;
+
+import com.dorandoran.store.client.ChatServiceClient;
+import com.dorandoran.store.client.dto.ChatRoomDto;
+import com.dorandoran.store.dto.request.BookmarkRequest;
+import com.dorandoran.store.dto.response.BookmarkResponse;
+import com.dorandoran.store.dto.response.StorageListResponse;
+import com.dorandoran.store.entity.Store;
+import com.dorandoran.store.exception.BookmarkNotFoundException;
+import com.dorandoran.store.exception.DuplicateBookmarkException;
+import com.dorandoran.store.exception.UnauthorizedAccessException;
+import com.dorandoran.store.repository.StoreRepository;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Storage Service
+ * 보관함 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StorageService {
+
+  private final StoreRepository storeRepository;
+  private final ChatServiceClient chatServiceClient;  // 채팅방 정보 획득
+
+  /**
+   * 표현 보관하기
+   */
+  @Transactional
+  public BookmarkResponse saveBookmark(UUID userId, BookmarkRequest request) {
+    log.info("표현 보관 시작: userId={}, messageId={}", userId, request.getMessageId());
+
+    // 중복 체크
+    if (storeRepository.existsByUserIdAndMessageIdAndIsDeletedFalse(userId, request.getMessageId())) {
+      log.warn("중복 저장 시도: userId={}, messageId={}", userId, request.getMessageId());
+      throw new DuplicateBookmarkException("이미 보관함에 저장된 표현입니다");
+    }
+
+    // Store 엔티티 생성
+    Store store = Store.builder()
+        .userId(userId)
+        .messageId(request.getMessageId())
+        .chatroomId(request.getChatroomId())
+//        .chatbotId(request.getChatbotId())
+        .content(request.getContent())
+        .aiResponse(request.getAiResponse())
+        .botType(request.getBotType())
+        .isDeleted(false)
+        .build();
+
+    Store saved = storeRepository.save(store);
+    log.info("표현 보관 완료: storeId={}", saved.getId());
+
+    return BookmarkResponse.from(saved, "표현이 보관함에 저장되었습니다");
+  }
+
+  /**
+   * 보관함 전체 조회
+   */
+  @Transactional(readOnly = true)
+  public List<StorageListResponse> getBookmarks(UUID userId) {
+    log.info("보관함 전체 조회: userId={}", userId);
+
+    List<Store> stores = storeRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(userId);
+
+    if (stores.isEmpty()) {
+      log.info("보관함이 비어있음: userId={}", userId);
+    }
+
+    return stores.stream()
+        .map(store -> enrichWithChatroomName(store))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 보관함 전체 조회 (페이징)
+   */
+  @Transactional(readOnly = true)
+  public Page<StorageListResponse> getBookmarks(UUID userId, Pageable pageable) {
+    log.info("보관함 조회 (페이징): userId={}, page={}, size={}",
+        userId, pageable.getPageNumber(), pageable.getPageSize());
+
+    Page<Store> stores = storeRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, pageable);
+
+    return stores.map(store -> enrichWithChatroomName(store));
+  }
+
+//  /**
+//   * 방별 보관함 조회
+//   */
+//  @Transactional(readOnly = true)
+//  public List<StorageListResponse> getBookmarksByChatroom(UUID userId, UUID chatroomId) {
+//    log.info("방별 보관함 조회: userId={}, chatroomId={}", userId, chatroomId);
+//
+//    List<Store> stores = storeRepository
+//        .findByUserIdAndChatroomIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, chatroomId);
+//
+//    if (stores.isEmpty()) {
+//      log.info("해당 채팅방의 보관함이 비어있음: chatroomId={}", chatroomId);
+//    }
+//
+//    // 방별 조회는 같은 채팅방이므로 한 번만 조회
+//    String chatroomName = "Unknown";
+//    try {
+//      chatroomName = chatServiceClient.getChatRoom(chatroomId).getName();
+//    } catch (Exception e) {
+//      log.warn("채팅방 이름 조회 실패: chatroomId={}", chatroomId, e);
+//    }
+//
+//    final String finalChatroomName = chatroomName;
+//    return stores.stream()
+//        .map(store -> {
+//          StorageListResponse response = StorageListResponse.from(store);
+//          response.setChatroomNameFromClient(finalChatroomName);
+//          return response;
+//        })
+//        .collect(Collectors.toList());
+//  }
+//
+//  /**
+//   * 방별 보관함 조회 (페이징)
+//   */
+//  @Transactional(readOnly = true)
+//  public Page<StorageListResponse> getBookmarksByChatroom(UUID userId, UUID chatroomId, Pageable pageable) {
+//    log.info("방별 보관함 조회 (페이징): userId={}, chatroomId={}", userId, chatroomId);
+//
+//    Page<Store> stores = storeRepository
+//        .findByUserIdAndChatroomIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, chatroomId, pageable);
+//
+//    // 방별 조회는 같은 채팅방이므로 한 번만 조회
+//    String chatroomName = "Unknown";
+//    try {
+//      chatroomName = chatServiceClient.getChatRoom(chatroomId).getName();
+//    } catch (Exception e) {
+//      log.warn("채팅방 이름 조회 실패: chatroomId={}", chatroomId, e);
+//    }
+//
+//    final String finalChatroomName = chatroomName;
+//    return stores.map(store -> {
+//      StorageListResponse response = StorageListResponse.from(store);
+//      response.setChatroomNameFromClient(finalChatroomName);
+//      return response;
+//    });
+//  }
+
+  /**
+   * botType별 조회
+   */
+  @Transactional(readOnly = true)
+  public List<StorageListResponse> getBookmarksByBotType(UUID userId, String botType) {
+    log.info("챗봇 타입별 보관함 조회: userId={}, botType={}", userId, botType);
+
+    List<Store> stores = storeRepository
+        .findByUserIdAndBotTypeAndIsDeletedFalseOrderByCreatedAtDesc(userId, botType);
+
+    if (stores.isEmpty()) {
+      log.info("해당 챗봇 타입의 보관함이 비어있음: botType={}", botType);
+    }
+
+    return stores.stream()
+        .map(store -> enrichWithChatroomName(store))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Cursor 기반 페이징 조회
+   */
+  @Transactional(readOnly = true)
+  public Page<StorageListResponse> getBookmarksWithCursor(UUID userId, UUID lastId, Pageable pageable) {
+    log.info("Cursor 기반 보관함 조회: userId={}, lastId={}, size={}",
+        userId, lastId, pageable.getPageSize());
+
+    Page<Store> stores = storeRepository.findByUserIdWithCursor(userId, lastId, pageable);
+
+    return stores.map(store -> enrichWithChatroomName(store));
+  }
+
+  /**
+   * 보관함 삭제 (소프트 삭제)
+   */
+  @Transactional
+  public void deleteBookmark(UUID userId, UUID bookmarkId) {
+    log.info("보관함 삭제: userId={}, bookmarkId={}", userId, bookmarkId);
+
+    Store store = storeRepository.findById(bookmarkId)
+        .orElseThrow(() -> new BookmarkNotFoundException("보관함 항목을 찾을 수 없습니다"));
+
+    // 권한 확인
+    if (!store.getUserId().equals(userId)) {
+      log.warn("삭제 권한 없음: userId={}, storeUserId={}", userId, store.getUserId());
+      throw new UnauthorizedAccessException("삭제 권한이 없습니다");
+    }
+
+    // 이미 삭제됨
+    if (store.getIsDeleted()) {
+      log.warn("이미 삭제된 항목: bookmarkId={}", bookmarkId);
+      throw new IllegalStateException("이미 삭제된 항목입니다");
+    }
+
+    // 소프트 삭제
+    store.setIsDeleted(true);
+    store.setDeletedAt(LocalDateTime.now());
+    storeRepository.save(store);
+
+    log.info("보관함 삭제 완료: bookmarkId={}", bookmarkId);
+  }
+
+  /**
+   * 보관함 일괄 삭제 (소프트 삭제)
+   */
+  @Transactional
+  public void deleteBookmarks(UUID userId, List<UUID> bookmarkIds) {
+    log.info("보관함 일괄 삭제: userId={}, count={}", userId, bookmarkIds.size());
+
+    for (UUID bookmarkId : bookmarkIds) {
+      try {
+        deleteBookmark(userId, bookmarkId);
+      } catch (Exception e) {
+        log.error("삭제 실패: bookmarkId={}", bookmarkId, e);
+        // 실패해도 계속 진행
+      }
+    }
+
+    log.info("보관함 일괄 삭제 완료: userId={}", userId);
+  }
+
+  /**
+   * 보관함 개수 조회
+   */
+  @Transactional(readOnly = true)
+  public long countBookmarks(UUID userId) {
+    return storeRepository.countByUserIdAndIsDeletedFalse(userId);
+  }
+
+//  /**
+//   * 챗봇별 보관함 조회
+//   */
+//  @Transactional(readOnly = true)
+//  public List<StorageListResponse> getBookmarksByChatbot(UUID userId, UUID chatbotId) {
+//    log.info("챗봇별 보관함 조회: userId={}, chatbotId={}", userId, chatbotId);
+//
+//    List<Store> stores = storeRepository
+//        .findByUserIdAndChatbotIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, chatbotId);
+//
+//    if (stores.isEmpty()) {
+//      log.info("해당 챗봇의 보관함이 비어있음: chatbotId={}", chatbotId);
+//    }
+//
+//    return stores.stream()
+//        .map(store -> {
+//          StorageListResponse response = StorageListResponse.from(store);
+//          try {
+//            String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
+//            response.setChatroomNameFromClient(chatroomName);
+//          } catch (Exception e) {
+//            log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
+//            response.setChatroomNameFromClient("Unknown");
+//          }
+//          return response;
+//        })
+//        .collect(Collectors.toList());
+//  }
+
+  /**
+   * botType별 조회
+   * @param userId
+   * @param botType
+   * @return
+   */
+  @Transactional(readOnly = true)
+  public List<StorageListResponse> getBookmarksByBotType(UUID userId, String botType) {
+    log.info("챗봇 타입별 보관함 조회: userId={}, botType={}", userId, botType);
+
+    List<Store> stores = storeRepository
+        .findByUserIdAndBotTypeAndIsDeletedFalseOrderByCreatedAtDesc(userId, botType);
+
+    if (stores.isEmpty()) {
+      log.info("해당 챗봇 타입의 보관함이 비어있음: botType={}", botType);
+    }
+
+    return stores.stream()
+        .map(store -> {
+          StorageListResponse response = StorageListResponse.from(store);
+          try {
+            String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
+            response.setChatroomNameFromClient(chatroomName);
+          } catch (Exception e) {
+            log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
+            response.setChatroomNameFromClient("Unknown");
+          }
+          return response;
+        })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Cursor 기반 페이징 조회
+   */
+  @Transactional(readOnly = true)
+  public Page<StorageListResponse> getBookmarksWithCursor(UUID userId, UUID lastId, Pageable pageable) {
+    log.info("Cursor 기반 보관함 조회: userId={}, lastId={}, size={}",
+        userId, lastId, pageable.getPageSize());
+
+    Page<Store> stores = storeRepository.findByUserIdWithCursor(userId, lastId, pageable);
+
+    return stores.map(store -> {
+      StorageListResponse response = StorageListResponse.from(store);
+      try {
+        String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
+        response.setChatroomNameFromClient(chatroomName);
+      } catch (Exception e) {
+        log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
+        response.setChatroomNameFromClient("Unknown");
+      }
+      return response;
+    });
+  }
+}

--- a/store/src/main/java/com/dorandoran/store/service/StorageService.java
+++ b/store/src/main/java/com/dorandoran/store/service/StorageService.java
@@ -55,6 +55,7 @@ public class StorageService {
         .chatroomId(request.getChatroomId())
 //        .chatbotId(request.getChatbotId())
         .content(request.getContent())
+        .correctedContent(request.getCorrectedContent())
         .aiResponse(request.getAiResponse())
         .botType(request.getBotType())
         .isDeleted(false)

--- a/store/src/main/java/com/dorandoran/store/service/StorageService.java
+++ b/store/src/main/java/com/dorandoran/store/service/StorageService.java
@@ -228,13 +228,14 @@ public class StorageService {
       try {
         deleteBookmark(userId, bookmarkId);
       } catch (Exception e) {
-        log.error("삭제 실패: bookmarkId={}", bookmarkId, e);
+        log.error("삭제 실패 - 계속 진행합니다: bookmarkId={}", bookmarkId, e);
         // 실패해도 계속 진행
       }
     }
 
     log.info("보관함 일괄 삭제 완료: userId={}", userId);
   }
+
 
   /**
    * 보관함 개수 조회
@@ -244,87 +245,52 @@ public class StorageService {
     return storeRepository.countByUserIdAndIsDeletedFalse(userId);
   }
 
-//  /**
-//   * 챗봇별 보관함 조회
-//   */
-//  @Transactional(readOnly = true)
-//  public List<StorageListResponse> getBookmarksByChatbot(UUID userId, UUID chatbotId) {
-//    log.info("챗봇별 보관함 조회: userId={}, chatbotId={}", userId, chatbotId);
-//
-//    List<Store> stores = storeRepository
-//        .findByUserIdAndChatbotIdAndIsDeletedFalseOrderByCreatedAtDesc(userId, chatbotId);
-//
-//    if (stores.isEmpty()) {
-//      log.info("해당 챗봇의 보관함이 비어있음: chatbotId={}", chatbotId);
-//    }
-//
-//    return stores.stream()
-//        .map(store -> {
-//          StorageListResponse response = StorageListResponse.from(store);
-//          try {
-//            String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
-//            response.setChatroomNameFromClient(chatroomName);
-//          } catch (Exception e) {
-//            log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
-//            response.setChatroomNameFromClient("Unknown");
-//          }
-//          return response;
-//        })
-//        .collect(Collectors.toList());
-//  }
 
   /**
-   * botType별 조회
-   * @param userId
-   * @param botType
-   * @return
+   * 채팅방 이름을 조회하여 StorageListResponse에 추가
+   * Feign Client 예외 처리 포함
    */
-  @Transactional(readOnly = true)
-  public List<StorageListResponse> getBookmarksByBotType(UUID userId, String botType) {
-    log.info("챗봇 타입별 보관함 조회: userId={}, botType={}", userId, botType);
+  private StorageListResponse enrichWithChatroomName(Store store) {
+    StorageListResponse response = StorageListResponse.from(store);
 
-    List<Store> stores = storeRepository
-        .findByUserIdAndBotTypeAndIsDeletedFalseOrderByCreatedAtDesc(userId, botType);
+    try {
+      // userId를 함께 전달하여 권한 체크
+      ChatRoomDto chatRoom = chatServiceClient.getChatRoom(
+          store.getChatroomId(),
+          store.getUserId()  // ← 추가
+      );
 
-    if (stores.isEmpty()) {
-      log.info("해당 챗봇 타입의 보관함이 비어있음: botType={}", botType);
-    }
-
-    return stores.stream()
-        .map(store -> {
-          StorageListResponse response = StorageListResponse.from(store);
-          try {
-            String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
-            response.setChatroomNameFromClient(chatroomName);
-          } catch (Exception e) {
-            log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
-            response.setChatroomNameFromClient("Unknown");
-          }
-          return response;
-        })
-        .collect(Collectors.toList());
-  }
-
-  /**
-   * Cursor 기반 페이징 조회
-   */
-  @Transactional(readOnly = true)
-  public Page<StorageListResponse> getBookmarksWithCursor(UUID userId, UUID lastId, Pageable pageable) {
-    log.info("Cursor 기반 보관함 조회: userId={}, lastId={}, size={}",
-        userId, lastId, pageable.getPageSize());
-
-    Page<Store> stores = storeRepository.findByUserIdWithCursor(userId, lastId, pageable);
-
-    return stores.map(store -> {
-      StorageListResponse response = StorageListResponse.from(store);
-      try {
-        String chatroomName = chatServiceClient.getChatRoom(store.getChatroomId()).getName();
-        response.setChatroomNameFromClient(chatroomName);
-      } catch (Exception e) {
-        log.warn("채팅방 이름 조회 실패: chatroomId={}", store.getChatroomId(), e);
+      if (chatRoom != null && chatRoom.getName() != null) {
+        response.setChatroomNameFromClient(chatRoom.getName());
+      } else {
+        log.warn("채팅방 정보가 null: chatroomId={}", store.getChatroomId());
         response.setChatroomNameFromClient("Unknown");
       }
-      return response;
-    });
+
+    } catch (FeignException.NotFound e) {
+      log.warn("채팅방을 찾을 수 없음: chatroomId={}", store.getChatroomId());
+      response.setChatroomNameFromClient("Deleted Room");
+
+    } catch (FeignException.Forbidden e) {
+      // 403 Forbidden 처리 추가
+      log.warn("채팅방 접근 권한 없음: chatroomId={}, userId={}",
+          store.getChatroomId(), store.getUserId());
+      response.setChatroomNameFromClient("Forbidden");
+
+    } catch (FeignException.ServiceUnavailable e) {
+      log.warn("Chat Service 일시적 장애: chatroomId={}", store.getChatroomId());
+      response.setChatroomNameFromClient("Unavailable");
+
+    } catch (FeignException e) {
+      log.warn("Feign 통신 오류: chatroomId={}, status={}, message={}",
+          store.getChatroomId(), e.status(), e.getMessage());
+      response.setChatroomNameFromClient("Unknown");
+
+    } catch (Exception e) {
+      log.error("채팅방 이름 조회 중 예상치 못한 오류: chatroomId={}", store.getChatroomId(), e);
+      response.setChatroomNameFromClient("Unknown");
+    }
+
+    return response;
   }
 }

--- a/store/src/main/resources/application-docker.yml
+++ b/store/src/main/resources/application-docker.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres:5432/dorandoran_db
+    username: ${POSTGRES_USER:doran}
+    password: ${POSTGRES_PASSWORD:doran_password}
+
+server:
+  port: 8084

--- a/store/src/main/resources/application.yml
+++ b/store/src/main/resources/application.yml
@@ -1,0 +1,65 @@
+spring:
+  application:
+    name: store-service
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/dorandoran
+    username: doran
+    password: doran
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_schema: store_schema
+
+  sql:
+    init:
+      mode: never
+
+server:
+  port: 8084
+
+# Actuator
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+
+# Logging
+logging:
+  level:
+    com.dorandoran.store: DEBUG
+    org.springframework.web: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+# Feign Client
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+        loggerLevel: FULL
+  chat-service:
+    url: ${FEIGN_CHAT_SERVICE_URL:http://localhost:8083}
+  circuitbreaker:
+    enabled: true
+
+# OpenAPI/Swagger
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: method


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->

- Chat, User, Auth 모듈 구현 상태 (2025.10.18 dev 브랜치)
- Store Service 기본 CRUD 구현 완료 (fix/store 브랜치)
- Docker 환경 미구성
- **Git 히스토리 정리로 인한 브랜치 분기 문제 발생**

### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->

- Chat Service와 Feign Client로 실시간 채팅방 정보 조회
- Docker Compose 수정
- 사용자 인증 헤더(`X-User-Id`) 처리 강화
- Feign Client 예외 처리 세분화 (403, 503 대응)
- 전체 통합 테스트 스크립트 작성 및 검증

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

### 1. 사용자 인증 및 권한 체크 강화
- **StorageController**: `X-User-Id` 헤더 처리 로직 추가
  - Security Context 우선, 헤더 fallback 방식
  - 모든 엔드포인트에 사용자 인증 적용
- **ChatServiceClient**: userId 파라미터 추가하여 Chat Service 권한 체크 연동
  - Chat Service에서 사용자별 채팅방 접근 권한 검증

### 2. Feign Client 예외 처리 세분화
- **StorageService.enrichWithChatroomName()**: 다양한 Feign 예외 상황별 대응
- Circuit Breaker 패턴 적용 (Fallback 클래스)

### 3. Security 설정 수정
- **SecurityConfig**: Public API 패턴 불일치 문제 해결
  - `/api/store/users/**` → `/api/store/user/**`
  - `/api/store/auth/**` 패턴 추가
  - CORS로직 제외

### 4. Chat Service 안정화
- **Flyway 마이그레이션 경로 수정**
  - `filesystem:docker/scripts` → `classpath:db/migration`

### 5. Docker Compose 완전 통합
- **Store Service 컨테이너 추가**
  - 포트: 8084
  - 환경변수: FEIGN_CHAT_SERVICE_URL, DATASOURCE_URL
  - 의존성: shared-db, chat-service

### 6. 환경변수 기반 설정
- **Store Service application.yml**
  - `FEIGN_CHAT_SERVICE_URL` 환경변수 사용

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->

### Gateway Service 변경
- **HomeController**: Store Service 라우팅 정보 추가
  - `/api/store/**` 패턴 반환

### Git 히스토리 문제 해결
- **문제 상황**: 
  - dev 브랜치에서 히스토리 정리 (프로젝트 구조 정리 및 서브모듈 제거)
  - 기존 fix/store 브랜치와 공통 조상 사라짐
  - GitHub에서 "entirely different commit histories" 에러 발생
- **해결 방법**:
  - dev 브랜치 clone 후 백업 브랜치 활용하여 복구

### API 변경 사항 (Breaking Changes)
- **BookmarkRequest**: `chatbotId` 필드 추가
  - 프론트엔드에서 요청 시 반드시 포함 필요
  - 챗봇 타입별 UUID 매핑 필요
  - 메시지 교정 내용 컬럼 추가

## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] **API 테스트** 
  - ✅ 채팅방 생성 (Chat Service) - 201 Created
  - ✅ 메시지 전송 (Chat Service) - 201 Created
  - ✅ 북마크 저장 (Store Service) - 201 Created
  - ✅ 북마크 전체 조회 - 200 OK
  - ✅ 페이징 조회 (Offset) - 200 OK
  - ✅ Cursor 페이징 조회 - 200 OK
  - ✅ 챗봇 타입별 조회 (friend) - 200 OK
  - ✅ 북마크 개수 조회 - 200 OK
  - ✅ 중복 저장 방지 - 409 Conflict
  - ✅ 북마크 삭제 - 204 No Content
  - ✅ 삭제 후 조회 확인 - 200 OK (빈 배열)
  - ✅ Feign Client 동작 확인 - chatroomName 정상 조회