### PR TITLE
feat(user,auth): 회원 하드 삭제 API 및 Auth 토큰 무효화 내부 API

### DIFF
--- a/auth/src/main/java/com/dorandoran/auth/controller/AuthController.java
+++ b/auth/src/main/java/com/dorandoran/auth/controller/AuthController.java
@@ -477,4 +477,19 @@ public class AuthController {
                     .body(ApiResponse.error("사용자 정보 조회 중 오류가 발생했습니다.", ErrorCode.INTERNAL_SERVER_ERROR.getCode()));
         }
     }
+
+    /**
+     * 내부 API: 회원 탈퇴(하드 삭제) 시 해당 사용자 토큰 즉시 무효화.
+     * User 서비스에서 HMAC 헤더로 호출.
+     */
+    @PostMapping("/internal/users/{userId}/invalidate-tokens")
+    public ResponseEntity<Void> invalidateTokensForUser(@PathVariable String userId) {
+        try {
+            authService.invalidateAllTokensForUser(userId);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            log.error("토큰 무효화 실패: userId={}", userId, e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
 }

--- a/user/src/main/java/com/dorandoran/user/controller/UserController.java
+++ b/user/src/main/java/com/dorandoran/user/controller/UserController.java
@@ -337,6 +337,29 @@ public class UserController {
     }
     
     /**
+     * 회원탈퇴(하드 삭제): archive 이관 후 회원 레코드 물리 삭제.
+     * 본인만 가능: path userId와 X-User-Id(게이트웨이가 넣어주는 토큰 사용자) 일치 검증.
+     */
+    @DeleteMapping("/{userId}/hard")
+    public ResponseEntity<Void> hardDeleteUser(
+            @PathVariable String userId,
+            @RequestHeader(value = "X-User-Id", required = false) String authUserId) {
+        log.info("회원탈퇴(하드 삭제) 요청: userId={}", userId);
+        if (authUserId == null || !authUserId.equals(userId)) {
+            log.warn("회원탈퇴(하드 삭제) 권한 없음: path userId={}, X-User-Id={}", userId, authUserId);
+            return ResponseEntity.status(403).build();
+        }
+        try {
+            userService.hardDeleteUser(UUID.fromString(userId));
+            log.info("회원탈퇴(하드 삭제) 완료: userId={}", userId);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 사용자 ID: userId={}, error={}", userId, e.getMessage());
+            return ResponseEntity.badRequest().build();
+        }
+    }
+    
+    /**
      * 회원탈퇴 (소프트 삭제 - 상태를 INACTIVE로 변경)
      * 실제 삭제는 배치 작업에서 처리 예정
      */

--- a/user/src/main/java/com/dorandoran/user/service/AuthServiceIntegration.java
+++ b/user/src/main/java/com/dorandoran/user/service/AuthServiceIntegration.java
@@ -1,8 +1,12 @@
 package com.dorandoran.user.service;
 
+import com.dorandoran.user.admin.client.ChatServiceRequestSigner;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -16,6 +20,7 @@ import org.springframework.web.client.RestTemplate;
 public class AuthServiceIntegration {
     
     private final RestTemplate restTemplate;
+    private final ChatServiceRequestSigner requestSigner;
     
     @Value("${auth.service.url:http://localhost:8081}")
     private String authServiceUrl;
@@ -73,6 +78,25 @@ public class AuthServiceIntegration {
             log.debug("이메일 인증 데이터는 TTL로 자동 삭제됩니다: email={}", email);
         } catch (Exception e) {
             log.warn("이메일 인증 데이터 삭제 실패: email={}, error={}", email, e.getMessage());
+        }
+    }
+
+    /**
+     * 회원 탈퇴(하드 삭제) 시 해당 사용자 토큰 즉시 무효화 (Auth 내부 API, HMAC).
+     */
+    public void invalidateTokensForUser(String userId) {
+        try {
+            String url = authServiceUrl + "/api/auth/internal/users/" + userId + "/invalidate-tokens";
+            HttpHeaders headers = new HttpHeaders();
+            headers.addAll(requestSigner.createHeaders("user-service"));
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+            ResponseEntity<Void> response = restTemplate.exchange(
+                    url, HttpMethod.POST, entity, Void.class);
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                log.warn("Auth 토큰 무효화 응답 비정상: userId={}, status={}", userId, response.getStatusCode());
+            }
+        } catch (Exception e) {
+            log.warn("Auth 토큰 무효화 호출 실패: userId={}, error={}", userId, e.getMessage());
         }
     }
 }

--- a/user/src/main/java/com/dorandoran/user/service/UserService.java
+++ b/user/src/main/java/com/dorandoran/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.dorandoran.common.exception.DoranDoranException;
 import com.dorandoran.common.exception.ErrorCode;
 import com.dorandoran.user.entity.User;
 import com.dorandoran.user.repository.UserRepository;
+import com.dorandoran.user.repository.UserStatsRepository;
 import com.dorandoran.user.util.EmailMaskingUtil;
 import com.dorandoran.shared.dto.CreateUserRequest;
 import com.dorandoran.shared.dto.UpdateUserRequest;
@@ -40,6 +41,8 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
     private final AuthServiceIntegration authServiceIntegration;
+    private final UserWithdrawalArchiveService userWithdrawalArchiveService;
+    private final UserStatsRepository userStatsRepository;
     
     /**
      * 사용자 생성
@@ -436,6 +439,30 @@ public class UserService {
         userRepository.save(user);
         
         System.out.println("사용자 삭제 완료: id=" + id);
+    }
+
+    /**
+     * 회원 탈퇴(하드 삭제): 토큰 무효화 → archive 이관 → 선행 삭제 → app_user 물리 삭제.
+     * {@link #deleteUser(UUID)} 는 소프트 삭제(INACTIVE)만 수행.
+     */
+    @Transactional
+    public void hardDeleteUser(UUID id) {
+        log.info("회원 탈퇴(하드 삭제) 시작: userId={}", id);
+
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> new DoranDoranException(ErrorCode.USER_NOT_FOUND));
+
+        authServiceIntegration.invalidateTokensForUser(id.toString());
+
+        userWithdrawalArchiveService.archiveUserData(id);
+
+        userWithdrawalArchiveService.deleteMonthlyUserCosts(id);
+        userStatsRepository.findById(id).ifPresent(userStatsRepository::delete);
+        userWithdrawalArchiveService.deleteUserChatbotLastInteraction(id);
+
+        userRepository.delete(user);
+
+        log.info("회원 탈퇴(하드 삭제) 완료: userId={}", id);
     }
     
     /**


### PR DESCRIPTION
- DELETE /api/users/{userId}/hard: 아카이브·선행 삭제 후 app_user 물리 삭제 (X-User-Id 검증)
- POST /api/auth/internal/users/{userId}/invalidate-tokens: 탈퇴 시 토큰 블랙리스트
- User: AuthServiceIntegration에서 HMAC으로 Auth 호출
- User: 기존 DELETE /api/users/{userId} 소프트 삭제 유지

Made-with: Cursor

# ❗️ 머지 지침: 반드시 Squash and Merge를 사용해 주세요. ❗️

## Purpose 🎯
하드 삭제까지 머지

## Changes 🛠️
계정 하드 삭제 부분이 user 서비스에 없어 머지합니다


## Checklist
  - **Feature → Develop** 머지 시: **Squash and Merge**를 사용합니다.
  - **Develop → Main** 릴리즈 시: **Create Merge Commit**를 사용합니다.

