### PR TITLE
fix : ManagementQueue 타입 수정 및 ChatRoomRepository 파라미터 수정

### DIFF
--- a/chat/src/main/java/com/dorandoran/chat/repository/ChatRoomRepository.java
+++ b/chat/src/main/java/com/dorandoran/chat/repository/ChatRoomRepository.java
@@ -63,16 +63,16 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID> {
     @Query(value = "SELECT cr.* FROM chat_schema.chatrooms cr " +
            "JOIN chat_schema.chatbots cb ON cr.chatbot_id = cb.id " +
            "WHERE (:userId IS NULL OR cr.user_id = CAST(:userId AS uuid)) " +
-           "AND (:from IS NULL OR cr.last_message_at >= :from) " +
-           "AND (:to IS NULL OR cr.last_message_at <= :to) " +
+           "AND (CAST(:from AS timestamp) IS NULL OR cr.last_message_at >= CAST(:from AS timestamp)) " +
+           "AND (CAST(:to AS timestamp) IS NULL OR cr.last_message_at <= CAST(:to AS timestamp)) " +
            "AND (:roomKey IS NULL OR (cr.settings->>'concept') = :roomKey) " +
            "AND (:intimacyLevel IS NULL OR cb.intimacy_level = :intimacyLevel) " +
            "ORDER BY cr.last_message_at DESC NULLS LAST",
            countQuery = "SELECT COUNT(*) FROM chat_schema.chatrooms cr " +
                        "JOIN chat_schema.chatbots cb ON cr.chatbot_id = cb.id " +
                        "WHERE (:userId IS NULL OR cr.user_id = CAST(:userId AS uuid)) " +
-                       "AND (:from IS NULL OR cr.last_message_at >= :from) " +
-                       "AND (:to IS NULL OR cr.last_message_at <= :to) " +
+                       "AND (CAST(:from AS timestamp) IS NULL OR cr.last_message_at >= CAST(:from AS timestamp)) " +
+                       "AND (CAST(:to AS timestamp) IS NULL OR cr.last_message_at <= CAST(:to AS timestamp)) " +
                        "AND (:roomKey IS NULL OR (cr.settings->>'concept') = :roomKey) " +
                        "AND (:intimacyLevel IS NULL OR cb.intimacy_level = :intimacyLevel)",
            nativeQuery = true)

--- a/user/src/main/java/com/dorandoran/user/admin/entity/ManagementQueue.java
+++ b/user/src/main/java/com/dorandoran/user/admin/entity/ManagementQueue.java
@@ -4,6 +4,8 @@ import com.dorandoran.user.admin.enums.QueueStatus;
 import com.dorandoran.user.admin.enums.QueueType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -46,6 +48,7 @@ public class ManagementQueue {
    * - messageId, chatroomId, items, memo, details 등
    * - String으로 저장 후 ObjectMapper로 파싱
    */
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "request_data", columnDefinition = "jsonb", nullable = false)
   private String requestData;
 
@@ -54,6 +57,7 @@ public class ManagementQueue {
    * - processedBy, processedAt, action, note 등
    * - 처리 완료 시에만 저장
    */
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "result_data", columnDefinition = "jsonb")
   private String resultData;
 


### PR DESCRIPTION
## 📝 기존 상태

- `ManagementQueue` 엔티티의 `requestData`, `resultData` 필드가 `String` 타입으로 선언되어 있으나 DB 컬럼이 `jsonb` 타입이라 Hibernate 6에서 insert 시 타입 불일치로 500 에러 발생
- `ChatRoomRepository`의 `findAdminConversations` 쿼리에서 `CAST(:from AS timestamp)` 적용 후에도 `could not determine data type of parameter $3` 에러 지속 발생

## 💡PR에서 핵심적으로 변경된 사항

- `ManagementQueue`: `requestData`, `resultData` 필드에 `@JdbcTypeCode(SqlTypes.JSON)` 추가
- `ChatRoomRepository`: `findAdminConversations`의 `from`, `to` 파라미터에 `CAST(... AS timestamp)` 적용 (value, countQuery 각각)

## 📢이외 추가 변경 부분 및 기타

- `ArchAgentResult.payloadJson`, `ArchChatroom.meta`, `ArchMessage.metadataJson`도 동일한 jsonb/String 패턴이나 현재 쓰기가 발생하지 않아 이번 PR에서는 제외. 아카이빙 자동화 구현 시 함께 수정 필요.

## ✅ 테스트

- [ ] 테스트 코드
- [x] API 테스트 (배포 후 관리 필요 내역 등록 및 dataSource=chat 조회 확인 필요)