### PR TITLE
fix:dataSource=chat으로 채팅 로그 목록 조회 시 roomKey가 chatroomName에 매핑되어 conce…

### DIFF
--- a/user/src/main/java/com/dorandoran/user/admin/service/ChatLogService.java
+++ b/user/src/main/java/com/dorandoran/user/admin/service/ChatLogService.java
@@ -142,7 +142,7 @@ public class ChatLogService {
     Long messageCount = item.get("lastSequenceNumber") instanceof Number
         ? ((Number) item.get("lastSequenceNumber")).longValue() : null;
 
-    return new ChatLogListResponse(chatroomId, roomKey, null, intimacyLevel, lastMessageAt, messageCount, null);
+    return new ChatLogListResponse(chatroomId, null, roomKey, intimacyLevel, lastMessageAt, messageCount, null);
   }
 
   /**


### PR DESCRIPTION
## 📝 기존 상태

- dataSource=chat으로 채팅 로그 목록 조회 시 roomKey가 chatroomName에 매핑되어 concept이 null로 표시되는 문제

## 💡PR에서 핵심적으로 변경된 사항

- `ChatLogService`: convertToChatLogListResponse에서 roomKey를 chatroomName 대신 concept에 매핑하도록 수정

## 📢이외 추가 변경 부분 및 기타

- userEmail은 Chat 서비스 응답에 포함되지 않아 null로 표시됨 (Chat 서비스 측 수정 필요)

## ✅ 테스트

- [ ] 테스트 코드
- [x] API 테스트 (배포 후 dataSource=chat 조회 시 concept 정상 표시 확인 필요)